### PR TITLE
Update backtesting.md

### DIFF
--- a/docs/backtesting.md
+++ b/docs/backtesting.md
@@ -65,10 +65,7 @@ optional arguments:
   --strategy-list STRATEGY_LIST [STRATEGY_LIST ...]
                         Provide a space-separated list of strategies to
                         backtest. Please note that timeframe needs to be set
-                        either in config or via command line. When using this
-                        together with `--export trades`, the strategy-name is
-                        injected into the filename (so `backtest-data.json`
-                        becomes `backtest-data-SampleStrategy.json`
+                        either in config or via command line. 
   --export {none,trades,signals}
                         Export backtest results (default: trades).
   --export-filename PATH, --backtest-filename PATH


### PR DESCRIPTION
the name of the strategy is *not* injected into any filename.

<!-- Thank you for sending your pull request. But first, have you included
unit tests, and is your code PEP8 conformant? [More details](https://github.com/freqtrade/freqtrade/blob/develop/CONTRIBUTING.md)
-->
## Summary
correction to manual re strategy name injection into filename
<!-- Explain in one sentence the goal of this PR -->

## What's new?

<!-- Explain in details what this PR solve or improve. You can include visuals. -->
just remove the sentence that claims name is injected

CONTRIBUTING.md read and understood.